### PR TITLE
fix set-output that Deprecated by Github action

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -14,4 +14,4 @@ then
 else
     echo "::debug::\$RESULT: $RESULT"
 fi
-echo ::set-output name=result::"$RESULT"
+echo "result=$RESULT" >> $GITHUB_OUTPUT


### PR DESCRIPTION
GitHub Actions: Deprecating save-state and set-output commands

https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/